### PR TITLE
fix command line in usage example

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -35,5 +35,4 @@ optional arguments:
 
 
 Sample ETSI SOL001 v0.10.0 package:
-     tosca-parser --template-file=toscaparser/tests/spec_samples/etsi_sol001/sunshinedb/sunshinedb.yaml -nrpv
-
+     tosca-parser --template-file=toscaparser/tests/spec_samples/etsi_sol001/sunshinedb/Definitions/sunshinedb.yaml -nrpv


### PR DESCRIPTION
The command line given in the usage example points at a non-existent file.  I've made what I take to be the obvious fix.

Having said that, it still doesn't work.  You seem to have turned issue reporting off on this repository: please say if there's some better way for me to report errors:

```
$ python tosca_parser.py --template-file=toscaparser/tests/spec_samples/etsi_sol001/sunshinedb/Definitions/sunshinedb.yaml -nrpv
2019-02-27 13:54:47,146 ERROR  (tosca-parser@26332:topology_template.py:85) - The required parameter modifiable_attributes is not provided
2019-02-27 13:54:47,146 ERROR  (tosca-parser@26332:topology_template.py:85) - The required parameter modifiable_attributes is not provided
Traceback (most recent call last):
  File "/data/developer/tosca-parser/tosca_parser.py", line 32, in <module>
    parser_shell.main()
  File "/data/developer/tosca-parser/toscaparser/shell.py", line 192, in main
    ParserShell().main(args)
  File "/data/developer/tosca-parser/toscaparser/shell.py", line 100, in main
    debug_mode=debug, verbose=verbose)
  File "/data/developer/tosca-parser/toscaparser/shell.py", line 115, in parse
    debug=debug_mode, verbose=verbose)
  File "/data/developer/tosca-parser/toscaparser/tosca_template.py", line 127, in __init__
    self.topology_template = self._topology_template()
  File "/data/developer/tosca-parser/toscaparser/tosca_template.py", line 158, in _topology_template
    self.sub_mapped_node_template)
  File "/data/developer/tosca-parser/toscaparser/topology_template.py", line 63, in __init__
    self._process_intrinsic_functions()
  File "/data/developer/tosca-parser/toscaparser/topology_template.py", line 299, in _process_intrinsic_functions
    for interface in node_template.interfaces:
  File "/data/developer/tosca-parser/toscaparser/entity_template.py", line 141, in interfaces
    self._interfaces = self._create_interfaces()
  File "/data/developer/tosca-parser/toscaparser/entity_template.py", line 355, in _create_interfaces
    value=op_def)
  File "/data/developer/tosca-parser/toscaparser/elements/interfaces.py", line 77, in __init__
    self.defs = self.TOSCA_DEF[interfacetype]
KeyError: 'Vnflcm'
```